### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Go
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/d0ubletr0uble/expecterlint/security/code-scanning/1](https://github.com/d0ubletr0uble/expecterlint/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to the least privileges necessary. In this case, the workflow only needs read access to repository contents, so the `permissions` block should specify `contents: read`.

The changes will be made to the `.github/workflows/test.yml` file, adding the `permissions` key at the root level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
